### PR TITLE
osc-recv: osc-remove-handler before deliver

### DIFF
--- a/src/osc.clj
+++ b/src/osc.clj
@@ -104,8 +104,8 @@
   [peer path & [timeout]]
   (let [p (promise)]
     (osc-handle peer path (fn [msg]
-                           (deliver p msg)
-                            (osc-remove-handler)))
+                            (osc-remove-handler)
+                            (deliver p msg)))
     (let [res (try
                 (if timeout
                   (.get (future @p) timeout TimeUnit/MILLISECONDS) ; Blocks until


### PR DESCRIPTION
Seems to fix an edge-case issue when traversing max4live objects and getting data on their properties. Unfortunately, I'm unable to come up with a test case, but hopefully looks safe enough based on inspection.
